### PR TITLE
Fix ruff lint issues

### DIFF
--- a/tests/test_tts_normalizer.py
+++ b/tests/test_tts_normalizer.py
@@ -92,7 +92,8 @@ class TestCenturyOrdinals:
             "The 19th century saw the 2nd Industrial Revolution in the 1st half"
         )
         expected = (
-            "The nineteenth century saw the second Industrial Revolution in the first half"
+            "The nineteenth century saw the second Industrial Revolution "
+            "in the first half"
         )
         result = normalizer._normalize_century_ordinals(input_text)
         assert result == expected
@@ -129,8 +130,14 @@ class TestLatinAbbreviations:
                 "Machine learning, i.e., automated pattern recognition",
                 "Machine learning, that is automated pattern recognition"
             ),
-            ("Various methods: classification, regression, etc.", "Various methods: classification, regression, et cetera"),
-            ("The algorithm was developed c. 1943 by Turing", "The algorithm was developed circa 1943 by Turing"),
+            (
+                "Various methods: classification, regression, etc.",
+                "Various methods: classification, regression, et cetera",
+            ),
+            (
+                "The algorithm was developed c. 1943 by Turing",
+                "The algorithm was developed circa 1943 by Turing",
+            ),
         ]
 
         for input_text, expected in test_cases:
@@ -145,7 +152,10 @@ class TestLatinAbbreviations:
 
         test_cases = [
             ("This includes E.G. algorithms", "This includes for example algorithms"),
-            ("Machine learning I.E. pattern recognition", "Machine learning that is pattern recognition"),
+            (
+                "Machine learning I.E. pattern recognition",
+                "Machine learning that is pattern recognition",
+            ),
             ("Various methods ETC.", "Various methods et cetera"),
         ]
 
@@ -176,7 +186,10 @@ class TestDecades:
         normalizer = TTSNormalizer()
 
         test_cases = [
-            ("The 1980s were transformative", "The nineteen eighties were transformative"),
+            (
+                "The 1980s were transformative",
+                "The nineteen eighties were transformative",
+            ),
             ("Music from the 1960s", "Music from the nineteen sixties"),
             ("The 1950s saw rapid growth", "The nineteen fifties saw rapid growth"),
             ("Technology in the 2020s", "Technology in the twenty twenties"),

--- a/wiki_extractor/cli.py
+++ b/wiki_extractor/cli.py
@@ -67,7 +67,10 @@ def _handle_search(search_term: str, args) -> Optional[str]:
 
 def _show_search_menu(results: list[dict], search_term: str) -> Optional[str]:
     """Display interactive search menu and return selected URL."""
-    print(f"\n{Colors.BOLD}{Colors.BLUE}Found {len(results)} results for '{search_term}':{Colors.END}\n")
+    print(
+        f"\n{Colors.BOLD}{Colors.BLUE}Found {len(results)} results for "
+        f"'{search_term}':{Colors.END}\n"
+    )
 
     for i, result in enumerate(results, 1):
         title = result["title"]
@@ -85,7 +88,11 @@ def _show_search_menu(results: list[dict], search_term: str) -> Optional[str]:
 
     while True:
         try:
-            choice = input(f"{Colors.YELLOW}Enter your choice (1-{len(results)}) or 'q' to quit: {Colors.END}").strip().lower()
+            prompt = (
+                f"{Colors.YELLOW}Enter your choice (1-{len(results)}) or "
+                f"'q' to quit: {Colors.END}"
+            )
+            choice = input(prompt).strip().lower()
 
             if choice == 'q':
                 print(f"{Colors.MAGENTA}Cancelled{Colors.END}")
@@ -97,7 +104,10 @@ def _show_search_menu(results: list[dict], search_term: str) -> Optional[str]:
                 print(f"{Colors.GREEN}Selected: {selected['title']}{Colors.END}")
                 return selected["url"]
             else:
-                print(f"{Colors.RED}Please enter a number between 1 and {len(results)}{Colors.END}")
+                print(
+                    f"{Colors.RED}Please enter a number between 1 and "
+                    f"{len(results)}{Colors.END}"
+                )
         except ValueError:
             print(f"{Colors.RED}Please enter a valid number or 'q' to quit{Colors.END}")
         except KeyboardInterrupt:
@@ -417,11 +427,10 @@ def _write_outputs(
 
     if args.tts_file:
         # Apply normalization if requested
-        content_for_tts = (
-            tts_normalize_for_tts(markdown_content) 
-            if args.tts_normalize 
-            else markdown_content
-        )
+        if args.tts_normalize:
+            content_for_tts = tts_normalize_for_tts(markdown_content)
+        else:
+            content_for_tts = markdown_content
         tts_text = make_tts_friendly(
             content_for_tts, heading_prefix=args.heading_prefix
         )

--- a/wiki_extractor/client.py
+++ b/wiki_extractor/client.py
@@ -52,7 +52,9 @@ class WikiClient:
         resp.raise_for_status()
         return resp.json()
 
-    def search_articles(self, query: str, limit: int = 10, timeout: int = 15) -> list[dict]:
+    def search_articles(
+        self, query: str, limit: int = 10, timeout: int = 15
+    ) -> list[dict]:
         """Search for Wikipedia articles using OpenSearch API with fuzzy matching."""
         api_url = "https://en.wikipedia.org/w/api.php"
         params = {
@@ -82,7 +84,11 @@ class WikiClient:
             results.append({
                 "title": title,
                 "description": descriptions[i] if i < len(descriptions) else "",
-                "url": urls[i] if i < len(urls) else f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}"
+                "url": (
+                    urls[i]
+                    if i < len(urls)
+                    else f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}"
+                ),
             })
 
         return results


### PR DESCRIPTION
## Summary
- wrap long test strings and CLI prompts to satisfy ruff's 88-character limit
- refactor client search API signature and URL fallback for readability
- clarify TTS content selection with an explicit conditional

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa28f10e60832fad19da7e02a12413