### PR TITLE
Simplify CLI with positional article and aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,19 +61,19 @@ ruff check . --fix
 
 The tool can be used in multiple ways:
 
-1. **Direct script**: `python extract.py -a [url_or_search] [options]`
-2. **Module execution**: `python -m wiki_extractor -a [url_or_search] [options]`
-3. **Console script**: `wiki-extractor -a [url_or_search] [options]` (after `pip install -e .`)
+1. **Direct script**: `python extract.py [url_or_search] [options]`
+2. **Module execution**: `python -m wiki_extractor [url_or_search] [options]`
+3. **Console script**: `wiki-extractor [url_or_search] [options]` (after `pip install -e .`)
 4. **Programmatic**: Import functions from `wiki_extractor` package
 
 ### New Search Feature
 
 The tool now supports free-form search terms in addition to URLs:
 
-- **URL input**: `wiki-extractor -a "https://en.wikipedia.org/wiki/Wars_of_the_Roses"`
-- **Search input**: `wiki-extractor -a "war of the roses"`
-- **Fuzzy search**: `wiki-extractor -a "war fo the rose"` (handles typos)
-- **Auto-select**: `wiki-extractor -a "wars roses" --yolo` (picks first result)
+- **URL input**: `wiki-extractor "https://en.wikipedia.org/wiki/Wars_of_the_Roses"`
+- **Search input**: `wiki-extractor "war of the roses"`
+- **Fuzzy search**: `wiki-extractor "war fo the rose"` (handles typos)
+- **Auto-select**: `wiki-extractor "wars roses" --yolo` (picks first result)
 
 The search feature provides:
 - Interactive colored menu for multiple results
@@ -86,7 +86,7 @@ The search feature provides:
 - **No emojis**: The interface uses ANSI colors instead of emojis for better readability and professionalism
 - **Numbered menu**: Uses simple number selection (1-10) + Enter rather than arrow key navigation for cross-platform compatibility across all terminals (Windows Command Prompt, PowerShell, macOS Terminal, Linux terminals, CI/CD environments, SSH sessions)
 
-Key CLI options: `--article/-a` (required), `--yolo/-y`, `--output-dir`, `--tts-file`, `--tts-audio`, `--heading-prefix`, `--lead-only`, `--verbose`
+Key CLI options: `article` (positional), `--yolo/-y`, `--output/-o`, `--tts`, `--audio`, `--heading-prefix`, `--lead-only/-l`, `--verbose/-v`
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ pip install wiki-extractor
 pipx install wiki-extractor
 
 # extract an article and produce TTS file
-wiki-extractor -a "https://en.wikipedia.org/wiki/Homer" --tts-file --heading-prefix "Section:" -o output
+wiki-extractor "Homer" --tts --heading-prefix "Section:" -o output
 ```
 
 Usage
 
-- CLI flags: `--article/-a` (required), `--yolo/-y`, `--output-dir`, `--filename`, `--no-save`, `--timeout`, `--lead-only`, `--tts-file`, `--heading-prefix`, `--verbose`.
+- CLI flags: `article` (positional), `--yolo/-y`, `--output/-o`, `--filename/-f`, `--no-save/-n`, `--timeout/-t`, `--lead-only/-l`, `--tts`, `--heading-prefix`, `--verbose/-v`.
 
 **New Search Feature**: The tool now accepts both Wikipedia URLs and free-form search terms:
 
 ```powershell
 # URL (traditional)
-wiki-extractor -a "https://en.wikipedia.org/wiki/Homer" --tts-file -o output
+wiki-extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 
 # Search term with fuzzy matching
-wiki-extractor -a "homer ancient greek poet" --tts-file -o output
+wiki-extractor "homer ancient greek poet" --tts -o output
 
 # Auto-select first result (--yolo)
-wiki-extractor -a "homer poet" --yolo --tts-file -o output
+wiki-extractor "homer poet" --yolo --tts -o output
 ```
 
 Notes
@@ -60,8 +60,8 @@ After installation the `wiki-extractor` console script is available. You can als
 
 ```powershell
 # console script
-wiki-extractor -a "https://en.wikipedia.org/wiki/Homer" --tts-file -o output
+wiki-extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 
 # run via module
-python -m wiki_extractor -a "https://en.wikipedia.org/wiki/Homer" --tts-file -o output
+python -m wiki_extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 ```

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -13,9 +13,9 @@ def test_module_entrypoint_runs(monkeypatch, capsys):
     monkeypatch.setattr(cli, "extract_wikipedia_text", fake_extract)
 
     # Provide args for the module so the CLI runs quickly and doesn't write files
-    # Simulate: python -m wiki_extractor -a https://example.org/wiki/Fake
+    # Simulate: python -m wiki_extractor https://example.org/wiki/Fake
     monkeypatch.setattr(
-        sys, "argv", ["wiki_extractor", "-a", "https://example.org/wiki/Fake"]
+        sys, "argv", ["wiki_extractor", "https://example.org/wiki/Fake"]
     )
 
     # Running the module should not raise

--- a/wiki_extractor/cli.py
+++ b/wiki_extractor/cli.py
@@ -216,14 +216,14 @@ def main():
         description=("Extract plain text from a Wikipedia article")
     )
     parser.add_argument(
-        "-a",
-        "--article",
-        required=True,
+        "article",
         help=("Wikipedia article URL or search term"),
     )
     parser.add_argument(
         "-o",
+        "--output",
         "--output-dir",
+        dest="output_dir",
         default=os.path.join(os.getcwd(), "output"),
         help="Directory to save output",
     )
@@ -233,23 +233,28 @@ def main():
         help=("Base filename to use (otherwise derived from title)"),
     )
     parser.add_argument(
+        "-n",
         "--no-save",
         action="store_true",
         help="Do not save to file; print to stdout",
     )
     parser.add_argument(
+        "-t",
         "--timeout",
         type=int,
         default=15,
         help="HTTP timeout seconds",
     )
     parser.add_argument(
+        "-l",
         "--lead-only",
         action="store_true",
         help="Fetch only the lead (intro) section",
     )
     parser.add_argument(
+        "--tts",
         "--tts-file",
+        dest="tts_file",
         action="store_true",
         help=("Also produce a TTS-friendly .txt alongside the .md"),
     )
@@ -265,7 +270,9 @@ def main():
         help="Verbose logging",
     )
     parser.add_argument(
+        "--audio",
         "--tts-audio",
+        dest="tts_audio",
         action="store_true",
         help="Also produce an audio file via the local Kokoro/OpenAI-compatible TTS",
     )


### PR DESCRIPTION
## Summary
- accept article as positional argument instead of `-a/--article`
- add concise CLI flags like `--tts` and `-o/--output`
- update docs and tests for new usage

## Testing
- `pre-commit run --files wiki_extractor/cli.py README.md tests/test_entrypoint.py CLAUDE.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3e489318832fa634dbb2bff0d2ea