### PR TITLE
refactor: migrate CLI to Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "num2words>=0.5.0",
     "openai>=1.0.0",
     "requests>=2.0",
+    "typer>=0.12",
 ]
 
 [project.optional-dependencies]
@@ -33,7 +34,7 @@ dev = [
 ]
 
 [project.scripts]
-wiki-extractor = "wiki_extractor.cli:main"
+wiki-extractor = "wiki_extractor.cli:app"
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,26 +1,21 @@
-import runpy
-import sys
+from typer.testing import CliRunner
 
 
-def test_module_entrypoint_runs(monkeypatch, capsys):
-    # Replace network call with a stub that returns predictable values
+def test_cli_runs(monkeypatch):
+    """Ensure the Typer CLI can be invoked without errors."""
+
     def fake_extract(url, **kwargs):
         return ("Fake content.", "Fake Title")
 
-    # Monkeypatch the extract function used by the CLI
     import wiki_extractor.cli as cli
 
     monkeypatch.setattr(cli, "extract_wikipedia_text", fake_extract)
 
-    # Provide args for the module so the CLI runs quickly and doesn't write files
-    # Simulate: python -m wiki_extractor https://example.org/wiki/Fake
-    monkeypatch.setattr(
-        sys, "argv", ["wiki_extractor", "https://example.org/wiki/Fake"]
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["https://example.org/wiki/Fake", "--no-save"],
     )
 
-    # Running the module should not raise
-    runpy.run_module("wiki_extractor", run_name="__main__")
-
-    # capture output to ensure it wrote the success message
-    captured = capsys.readouterr()
-    assert "Output saved to" in captured.out or "Fake content." in captured.out
+    assert result.exit_code == 0
+    assert "Fake content." in result.stdout

--- a/wiki_extractor/__main__.py
+++ b/wiki_extractor/__main__.py
@@ -10,7 +10,7 @@ from . import cli as _cli
 
 
 def _main() -> None:
-    _cli.main()
+    _cli.app()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace argparse CLI with Typer app and expose `app()`
- update module entrypoint and packaging to call Typer app
- adjust tests to invoke CLI using Typer's `CliRunner`

## Testing
- `pre-commit run --files pyproject.toml wiki_extractor/cli.py wiki_extractor/__main__.py tests/test_entrypoint.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa42667164832f8c6283c2a3c10690