### PR TITLE
Add pipx installer and binary release workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,32 @@
+name: release-binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }} binary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pyinstaller
+      - name: Build binary
+        run: pyinstaller wiki_extractor/cli.py --name wiki-extractor --onefile
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/wiki-extractor*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: install
+
+# Install wiki-extractor with pipx and verify CLI is available
+install:
+	@command -v pipx >/dev/null 2>&1 || { echo "pipx is required: https://pipx.pypa.io/stable/installation/"; exit 1; }
+	pipx install . --force
+	wiki-extractor --help >/dev/null
+	@echo "wiki-extractor installed and verified"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ pipx install wiki-extractor
 wiki-extractor "Homer" --tts --heading-prefix "Section:" -o output
 ```
 
+### One-step pipx install
+
+The repository provides a small `Makefile` helper that installs the package
+with [pipx](https://pipx.pypa.io/) and verifies the command is available:
+
+```bash
+make install
+```
+
+This checks that `pipx` is present, installs the project and runs
+`wiki-extractor --help` to confirm everything is wired up.
+
 Usage
 
 - CLI flags: `article` (positional), `--yolo/-y`, `--output/-o`, `--filename/-f`, `--no-save/-n`, `--timeout/-t`, `--lead-only/-l`, `--tts`, `--heading-prefix`, `--verbose/-v`.
@@ -66,3 +78,18 @@ wiki-extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 # run via module
 python -m wiki_extractor "https://en.wikipedia.org/wiki/Homer" --tts -o output
 ```
+
+### Standalone binaries
+
+Release builds include standalone executables for Windows, macOS and
+Linux created with PyInstaller. Download the file for your platform from
+the [releases page](https://github.com/patrickdeanbrown/wiki_extractor/releases),
+make it executable if necessary (`chmod +x wiki-extractor` on
+Unix-like systems) and run it directly:
+
+```bash
+./wiki-extractor "Homer" --tts --heading-prefix "Section:" -o output
+```
+
+These binaries bundle Python so no interpreter or virtual environment is
+required.


### PR DESCRIPTION
## Summary
- provide `make install` helper that verifies pipx and the CLI
- document one-step pipx install and downloadable standalone binaries
- add release workflow to build PyInstaller executables for Windows, macOS, and Linux

## Testing
- `pre-commit run --files Makefile README.md .github/workflows/release-binaries.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa489f96a4832fa8bee15adba46163