### PR TITLE
Use module entry point in PyInstaller build

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -42,7 +42,7 @@ jobs:
       # Build: onefile everywhere (macOS will be signed with LV entitlement)
       - name: Build (PyInstaller onefile)
         run: |
-          pyinstaller wiki_extractor/cli.py --name wiki-extractor --onefile
+          pyinstaller -m wiki_extractor.cli --name wiki-extractor --onefile
 
       # ---------- macOS: sign single-file with LV entitlement, ZIP-notarize (no stapling) ----------
       - name: Sign & Notarize macOS single-file (ZIP; no stapling)


### PR DESCRIPTION
## Summary
- build release binary using module entrypoint `wiki_extractor.cli`

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac397c4ac832fab210607ce460fa8