### PR TITLE
fix(release): correct pyinstaller build command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install . pyinstaller
 
       - name: Build (PyInstaller onefile)
-        run: pyinstaller -m wikibee.cli --name wikibee --onefile
+        run: pyinstaller wikibee/__main__.py --name wikibee --onefile
 
       - name: Rename artifact
         run: |


### PR DESCRIPTION
The previous command used 'pyinstaller -m wikibee.cli', which was not correctly interpreted by the build environment.

This commit changes the command to point directly to the package entrypoint, 'wikibee/__main__.py', which is the standard and more reliable way to specify the script for PyInstaller.