### PR TITLE
fix: ensure module entrypoint works for binaries

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Verify module entrypoint
+        run: python wikibee/__main__.py --help
       - name: Run tests
         run: |
           pytest -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           python -m pip install . pyinstaller
 
       - name: Build (PyInstaller onefile)
+        # Use package entrypoint to maintain consistent imports
         run: pyinstaller wikibee/__main__.py --name wikibee --onefile
 
       - name: Rename artifact

--- a/wikibee/__main__.py
+++ b/wikibee/__main__.py
@@ -5,7 +5,7 @@ Delegates to the CLI app function for command-line execution.
 
 from __future__ import annotations
 
-from . import cli as _cli
+from wikibee import cli as _cli
 
 
 def _main() -> None:


### PR DESCRIPTION
## Summary
- use absolute import in `__main__.py` so binaries run
- run module entrypoint in CI to catch regressions
- clarify release workflow to use package entrypoint

## Testing
- `ruff check .`
- `pre-commit run --all-files`
- `python wikibee/__main__.py --help`
- `python -m wikibee --help`
- `wikibee --help`
- `pytest -q`
- `python scripts/smoke_extract.py` *(fails: Unable to connect to proxy)*
- `pyinstaller wikibee/__main__.py --name wikibee --onefile`
- `./dist/wikibee --help`


------
https://chatgpt.com/codex/tasks/task_e_68ac74ad8418832fb05d573e9ce16dfd