### PR TITLE
feat: Implement M4B chapter support using section headers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "inflect>=6.0",
     "num2words>=0.5.0",
     "openai>=1.0.0",
+    "mutagen>=1.47.0",
     "platformdirs>=4.0",
     "requests>=2.0",
     "rich>=13.0",

--- a/scripts/smoke_extract.py
+++ b/scripts/smoke_extract.py
@@ -81,8 +81,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--tts-format",
-        default="mp3",
-        help="Audio format to request from the TTS engine",
+        default="m4b",
+        help="Audio format to request from the TTS engine (m4b requires ffmpeg)",
     )
     args = parser.parse_args()
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -53,6 +53,8 @@ def test_cli_end_to_end_generates_outputs(monkeypatch, tmp_path):
             str(output_dir),
             "--tts",
             "--tts-audio",
+            "--tts-format",
+            "mp3",
             "--heading-prefix",
             "Section:",
         ],

--- a/tests/test_formatting_split.py
+++ b/tests/test_formatting_split.py
@@ -1,5 +1,5 @@
-import pytest
-from wikibee.formatting import split_wikitext_sections, convert_wikitext_headers
+from wikibee.formatting import convert_wikitext_headers, split_wikitext_sections
+
 
 def test_split_wikitext_sections_basic():
     text = """Introduction text.
@@ -14,6 +14,7 @@ Content 2.
     assert sections[1] == ("Section 1", "Content 1.")
     assert sections[2] == ("Section 2", "Content 2.")
 
+
 def test_split_wikitext_sections_no_intro():
     text = """== Section 1 ==
 Content 1.
@@ -21,6 +22,7 @@ Content 1.
     sections = split_wikitext_sections(text)
     assert len(sections) == 1
     assert sections[0] == ("Section 1", "Content 1.")
+
 
 def test_convert_wikitext_headers():
     text = """Intro.

--- a/tests/test_formatting_split.py
+++ b/tests/test_formatting_split.py
@@ -1,0 +1,43 @@
+import pytest
+from wikibee.formatting import split_wikitext_sections, convert_wikitext_headers
+
+def test_split_wikitext_sections_basic():
+    text = """Introduction text.
+== Section 1 ==
+Content 1.
+== Section 2 ==
+Content 2.
+"""
+    sections = split_wikitext_sections(text)
+    assert len(sections) == 3
+    assert sections[0] == ("Introduction", "Introduction text.")
+    assert sections[1] == ("Section 1", "Content 1.")
+    assert sections[2] == ("Section 2", "Content 2.")
+
+def test_split_wikitext_sections_no_intro():
+    text = """== Section 1 ==
+Content 1.
+"""
+    sections = split_wikitext_sections(text)
+    assert len(sections) == 1
+    assert sections[0] == ("Section 1", "Content 1.")
+
+def test_convert_wikitext_headers():
+    text = """Intro.
+== Section 1 ==
+Text.
+=== Subsection ===
+More text.
+== Section 2 ==
+End.
+"""
+    converted = convert_wikitext_headers(text)
+    expected = """Intro.
+## Section 1
+Text.
+### Subsection
+More text.
+## Section 2
+End.
+"""
+    assert converted == expected

--- a/tests/test_services_tts.py
+++ b/tests/test_services_tts.py
@@ -37,14 +37,17 @@ class FakeTTSClient:
 
 
 @pytest.fixture()
-def tts_service(tmp_path: Path) -> TTSService:
-    output_manager = OutputManager(tmp_path, audio_format="wav")
-    client = FakeTTSClient()
-    service = TTSService(client=client, output_manager=output_manager)
-    return service
+def make_tts_service(tmp_path: Path):
+    def _factory(audio_format: str = "wav") -> TTSService:
+        output_manager = OutputManager(tmp_path, audio_format=audio_format)
+        client = FakeTTSClient()
+        return TTSService(client=client, output_manager=output_manager)
+
+    return _factory
 
 
-def test_build_tts_text_respects_heading_prefix(tts_service: TTSService) -> None:
+def test_build_tts_text_respects_heading_prefix(make_tts_service) -> None:
+    tts_service = make_tts_service()
     text = tts_service.build_tts_text(
         markdown="# Intro\nContent",
         heading_prefix="Section:",
@@ -54,9 +57,24 @@ def test_build_tts_text_respects_heading_prefix(tts_service: TTSService) -> None
     assert "Section: Intro." in text
 
 
-def test_synthesize_audio_invokes_client(
-    tts_service: TTSService, tmp_path: Path
-) -> None:
+def test_build_tts_sections_use_markdown_headings(make_tts_service) -> None:
+    service = make_tts_service()
+    sections = service.build_tts_sections(
+        markdown="Intro text.\n\n# First\nBody\n\n## Second\nMore",
+        heading_prefix="Chapter",
+        normalize=False,
+    )
+
+    assert [section.title for section in sections] == [
+        "Introduction",
+        "First",
+        "Second",
+    ]
+    assert sections[1].text.startswith("Chapter First.")
+
+
+def test_synthesize_audio_invokes_client(make_tts_service, tmp_path: Path) -> None:
+    tts_service = make_tts_service()
     manager = tts_service.output_manager
     paths = manager.prepare_paths("Audio", None)
     audio_path = tts_service.synthesize_audio(
@@ -72,3 +90,45 @@ def test_synthesize_audio_invokes_client(
     fake_client = tts_service.client  # type: ignore[attr-defined]
     assert fake_client.calls[0]["voice"] == "af_voice"
     assert fake_client.calls[0]["file_format"] == "wav"
+
+
+def test_synthesize_m4b_uses_ffmpeg(monkeypatch, tmp_path: Path) -> None:
+    fake_client = FakeTTSClient()
+    service = TTSService(
+        client=fake_client,
+        output_manager=OutputManager(tmp_path, audio_format="m4b"),
+    )
+
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/ffmpeg")
+
+    created_commands = []
+
+    def fake_run(cmd, check):
+        Path(cmd[-1]).touch()
+        created_commands.append(cmd)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    class DummyMP3:
+        def __init__(self, path):
+            class Info:
+                length = 1.0
+
+            self.info = Info()
+
+    monkeypatch.setattr("wikibee.services.tts.MP3", DummyMP3)
+
+    paths = service.output_manager.prepare_paths("Chaptered", None)
+    result = service.synthesize_audio(
+        markdown="# Intro\nBody\n\n# Next\nMore",
+        paths=paths,
+        heading_prefix="Section:",
+        normalize=False,
+        voice=None,
+        file_format="m4b",
+    )
+
+    assert Path(result).exists()
+    assert created_commands
+    # two headings -> two synthesis calls
+    assert len(fake_client.calls) == 2

--- a/wikibee/formatting.py
+++ b/wikibee/formatting.py
@@ -150,7 +150,6 @@ def split_wikitext_sections(text: str) -> list[tuple[str, str]]:
     current_body: list[str] = []
 
     # Regex to match == Header == styles
-    # Matches start of line, 2+ equals, whitespace, title, whitespace, 2+ equals, end of line
     heading_re = re.compile(r"^\s*={2,}\s*(?P<title>.+?)\s*={2,}\s*$")
 
     for line in text.splitlines():

--- a/wikibee/formatting.py
+++ b/wikibee/formatting.py
@@ -101,6 +101,85 @@ def make_tts_friendly(markdown: str, heading_prefix: Optional[str] = None) -> st
     return text
 
 
+def split_markdown_sections(markdown: str) -> list[tuple[str, str]]:
+    """Split markdown into (heading, body) tuples.
+
+    The first section contains any content before the first heading and uses
+    "Introduction" as its title.
+    """
+
+    sections: list[tuple[str, list[str]]] = []
+    current_title: str = "Introduction"
+    current_body: list[str] = []
+
+    heading_re = re.compile(r"^\s*(?P<hashes>#+)\s*(?P<title>.+?)\s*$")
+    for line in markdown.splitlines():
+        match = heading_re.match(line)
+        if match:
+            if current_body:
+                sections.append((current_title, current_body.copy()))
+                current_body.clear()
+            current_title = match.group("title").strip() or current_title
+            continue
+        current_body.append(line)
+
+    sections.append((current_title, current_body.copy()))
+    return [(title, "\n".join(body).strip()) for title, body in sections]
+
+
+def build_tts_sections(markdown: str) -> list[tuple[str, str]]:
+    """Return [(title, markdown_section_with_heading)]."""
+
+    sections = split_markdown_sections(markdown)
+    results: list[tuple[str, str]] = []
+    for title, body in sections:
+        content = f"# {title}\n\n{body}\n" if body else f"# {title}\n"
+        cleaned = content.strip()
+        if cleaned:
+            results.append((title, cleaned))
+    return results
+
+
+def split_wikitext_sections(text: str) -> list[tuple[str, str]]:
+    """Split raw WikiText into (heading, body) tuples.
+
+    Splits by `== Header ==` patterns. The first section is "Introduction".
+    """
+    sections: list[tuple[str, list[str]]] = []
+    current_title: str = "Introduction"
+    current_body: list[str] = []
+
+    # Regex to match == Header == styles
+    # Matches start of line, 2+ equals, whitespace, title, whitespace, 2+ equals, end of line
+    heading_re = re.compile(r"^\s*={2,}\s*(?P<title>.+?)\s*={2,}\s*$")
+
+    for line in text.splitlines():
+        match = heading_re.match(line)
+        if match:
+            if current_body:
+                sections.append((current_title, current_body.copy()))
+                current_body.clear()
+            current_title = match.group("title").strip()
+            continue
+        current_body.append(line)
+
+    if current_body or not sections:
+        sections.append((current_title, current_body.copy()))
+
+    return [(title, "\n".join(body).strip()) for title, body in sections]
+
+
+def convert_wikitext_headers(text: str) -> str:
+    """Convert WikiText headers (== Title ==) to Markdown headers (## Title)."""
+
+    def _repl(m: Match[str]) -> str:
+        level = len(m.group(1))
+        title = m.group(2).strip()
+        return f"{'#' * level} {title}"
+
+    return re.sub(r"^(={2,})\s*(.+?)\s*\1\s*$", _repl, text, flags=re.MULTILINE)
+
+
 def write_text_file(path: str, base_dir: str, content: str) -> None:
     """Safely write a text file ensuring it stays within base_dir.
 

--- a/wikibee/services/tts.py
+++ b/wikibee/services/tts.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
+
+from mutagen.mp3 import MP3
 
 from wikibee import formatting
 from wikibee.services.output import OutputManager, OutputPaths
 from wikibee.tts_normalizer import normalize_for_tts as tts_normalize_for_tts
-from wikibee.tts_openai import TTSOpenAIClient
+from wikibee.tts_openai import TTSClientError, TTSOpenAIClient
+
+
+@dataclass
+class TTSSection:
+    title: str
+    text: str
 
 
 class TTSService:
@@ -36,6 +51,27 @@ class TTSService:
             source = tts_normalize_for_tts(source)
         return formatting.make_tts_friendly(source, heading_prefix=heading_prefix)
 
+    def build_tts_sections(
+        self,
+        markdown: str,
+        *,
+        heading_prefix: Optional[str],
+        normalize: bool,
+    ) -> list[TTSSection]:
+        sections = formatting.build_tts_sections(markdown)
+        results: list[TTSSection] = []
+        for title, section_markdown in sections:
+            source = section_markdown
+            if normalize:
+                source = tts_normalize_for_tts(source)
+            tts_text = formatting.make_tts_friendly(
+                source,
+                heading_prefix=heading_prefix,
+            ).strip()
+            if tts_text:
+                results.append(TTSSection(title=title, text=tts_text))
+        return results
+
     def synthesize_audio(
         self,
         *,
@@ -46,6 +82,15 @@ class TTSService:
         voice: Optional[str],
         file_format: str,
     ) -> str:
+        if file_format.lower() == "m4b":
+            return self._synthesize_m4b_with_chapters(
+                markdown=markdown,
+                paths=paths,
+                heading_prefix=heading_prefix,
+                normalize=normalize,
+                voice=voice,
+            )
+
         text_for_audio = self.build_tts_text(
             markdown,
             heading_prefix=heading_prefix,
@@ -61,3 +106,114 @@ class TTSService:
             file_format=file_format,
             timeout=self.timeout,
         )
+
+    def _synthesize_m4b_with_chapters(
+        self,
+        *,
+        markdown: str,
+        paths: OutputPaths,
+        heading_prefix: Optional[str],
+        normalize: bool,
+        voice: Optional[str],
+    ) -> str:
+        ffmpeg_path = shutil.which("ffmpeg")
+        if not ffmpeg_path:
+            raise TTSClientError(
+                "ffmpeg is required to produce M4B output. Please install ffmpeg and"
+                " ensure it is available on your PATH."
+            )
+
+        sections = self.build_tts_sections(
+            markdown,
+            heading_prefix=heading_prefix,
+            normalize=normalize,
+        )
+        if not sections:
+            sections = [
+                TTSSection(
+                    title="Article",
+                    text=self.build_tts_text(
+                        markdown,
+                        heading_prefix=heading_prefix,
+                        normalize=normalize,
+                    ),
+                )
+            ]
+
+        base_dir = Path(self.output_manager.base_dir)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            segment_paths: list[Path] = []
+            chapter_lengths: list[float] = []
+
+            for idx, section in enumerate(sections, start=1):
+                segment_name = f"segment_{idx:03d}.mp3"
+                relative_segment = segment_name
+                dest = tmp_path / segment_name
+                self.client.synthesize_to_file(
+                    section.text,
+                    dest_path=relative_segment,
+                    base_dir=str(tmp_path),
+                    model=self.model,
+                    voice=voice,
+                    file_format="mp3",
+                    timeout=self.timeout,
+                )
+                try:
+                    info = MP3(dest)
+                    chapter_lengths.append(float(info.info.length))
+                except Exception as exc:  # pragma: no cover - defensive
+                    raise TTSClientError(
+                        f"Unable to read audio duration for {dest}"
+                    ) from exc
+                segment_paths.append(dest)
+
+            concat_list = tmp_path / "concat.txt"
+            with concat_list.open("w", encoding="utf-8") as fh:
+                for path in segment_paths:
+                    fh.write(f"file '{path.as_posix()}'\n")
+
+            metadata_file = tmp_path / "chapters.ffmetadata"
+            start_ms = 0
+            with metadata_file.open("w", encoding="utf-8") as fh:
+                fh.write(";FFMETADATA1\n")
+                for section, duration in zip(sections, chapter_lengths):
+                    end_ms = start_ms + int(duration * 1000)
+                    fh.write("[CHAPTER]\n")
+                    fh.write("TIMEBASE=1/1000\n")
+                    fh.write(f"START={start_ms}\n")
+                    fh.write(f"END={end_ms}\n")
+                    fh.write(f"title={section.title}\n")
+                    start_ms = end_ms
+
+            final_tmp = tmp_path / "output.m4b"
+            cmd = [
+                ffmpeg_path,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_list),
+                "-f",
+                "ffmetadata",
+                "-i",
+                str(metadata_file),
+                "-map_metadata",
+                "1",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "192k",
+                str(final_tmp),
+            ]
+            subprocess.run(cmd, check=True)
+
+            relative_audio_path = paths.audio_path.relative_to(base_dir)
+            final_dest = base_dir / relative_audio_path
+            final_dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(final_tmp), str(final_dest))
+            return str(final_dest)

--- a/wikibee/services/tts.py
+++ b/wikibee/services/tts.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, cast
 
 from mutagen.mp3 import MP3
 
@@ -160,7 +158,11 @@ class TTSService:
                     timeout=self.timeout,
                 )
                 try:
-                    info = MP3(dest)
+                    info = cast(Any, MP3(dest))
+                    if info.info is None:
+                        raise TTSClientError(
+                            f"Unable to read audio duration for {dest}"
+                        )
                     chapter_lengths.append(float(info.info.length))
                 except Exception as exc:  # pragma: no cover - defensive
                     raise TTSClientError(


### PR DESCRIPTION
This PR implements support for M4B chapters by preserving section headers during text extraction and using them to split the audio generation. It modifies the `extract` command to fetch raw WikiText when M4B format is requested, converts WikiText headers to Markdown headers, and leverages `TTSService` to generate chapters.