### PR TITLE
feat: Interactive Section Picker

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -66,6 +66,19 @@ wikibee "quantum physics" --yolo
 - Running automated scripts  
 - The first result is usually correct
 
+### --pick
+Interactively select which sections of the article to extract.
+
+```bash
+wikibee "Rome" --pick
+```
+
+**Features:**
+- Shows a numbered list of all sections
+- Supports selecting multiple sections (e.g., `1,3,5`)
+- Supports ranges (e.g., `1-4`)
+- Useful for extracting only specific parts of large articles
+
 ### --search-limit N
 Control how many search results to show (default: 10).
 

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from wikibee.commands.extract import _interactive_pick_sections
+
+@pytest.fixture
+def mock_console():
+    with patch("wikibee.commands.extract.console") as mock:
+        yield mock
+
+def test_interactive_pick_all(mock_console):
+    text = "Intro text\n== Section 1 ==\nContent 1\n== Section 2 ==\nContent 2"
+    mock_console.input.return_value = "all"
+    
+    result = _interactive_pick_sections(text)
+    assert result == text
+
+def test_interactive_pick_specific(mock_console):
+    text = "Intro text\n== Section 1 ==\nContent 1\n== Section 2 ==\nContent 2"
+    # Select Intro (1) and Section 2 (3)
+    mock_console.input.return_value = "1, 3"
+    
+    result = _interactive_pick_sections(text)
+    
+    # Expected: Intro body + Section 2 with header
+    # Intro body: "Intro text"
+    # Section 2: "== Section 2 ==\nContent 2"
+    expected = "Intro text\n\n== Section 2 ==\nContent 2"
+    assert result == expected
+
+def test_interactive_pick_range(mock_console):
+    text = "Intro\n== S1 ==\nC1\n== S2 ==\nC2\n== S3 ==\nC3"
+    # Select 2-3 (S1 and S2)
+    mock_console.input.return_value = "2-3"
+    
+    result = _interactive_pick_sections(text)
+    expected = "== S1 ==\nC1\n\n== S2 ==\nC2"
+    assert result == expected
+
+def test_interactive_pick_quit(mock_console):
+    text = "Intro"
+    mock_console.input.return_value = "q"
+    result = _interactive_pick_sections(text)
+    assert result == ""

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -1,40 +1,47 @@
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import MagicMock, patch
+
 from wikibee.commands.extract import _interactive_pick_sections
+
 
 @pytest.fixture
 def mock_console():
     with patch("wikibee.commands.extract.console") as mock:
         yield mock
 
+
 def test_interactive_pick_all(mock_console):
     text = "Intro text\n== Section 1 ==\nContent 1\n== Section 2 ==\nContent 2"
     mock_console.input.return_value = "all"
-    
+
     result = _interactive_pick_sections(text)
     assert result == text
+
 
 def test_interactive_pick_specific(mock_console):
     text = "Intro text\n== Section 1 ==\nContent 1\n== Section 2 ==\nContent 2"
     # Select Intro (1) and Section 2 (3)
     mock_console.input.return_value = "1, 3"
-    
+
     result = _interactive_pick_sections(text)
-    
+
     # Expected: Intro body + Section 2 with header
     # Intro body: "Intro text"
     # Section 2: "== Section 2 ==\nContent 2"
     expected = "Intro text\n\n== Section 2 ==\nContent 2"
     assert result == expected
 
+
 def test_interactive_pick_range(mock_console):
     text = "Intro\n== S1 ==\nC1\n== S2 ==\nC2\n== S3 ==\nC3"
     # Select 2-3 (S1 and S2)
     mock_console.input.return_value = "2-3"
-    
+
     result = _interactive_pick_sections(text)
     expected = "== S1 ==\nC1\n\n== S2 ==\nC2"
     assert result == expected
+
 
 def test_interactive_pick_quit(mock_console):
     text = "Intro"


### PR DESCRIPTION
Adds a `--pick` flag to the `extract` command, allowing users to interactively select which sections of a Wikipedia article to extract. This is useful for large articles where only specific sub-topics are needed.

Features:
- Interactive menu listing all sections
- Support for multiple selections (e.g. `1,3,5`)
- Support for ranges (e.g. `1-4`)
- Integration with existing TTS normalization and M4B header preservation logic